### PR TITLE
Add copyparty file server service on daphne

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -173,3 +173,9 @@ services:
     type: webapp
     machine: 192.168.0.12
     port: 8080
+
+  # Copyparty - File server with resumable uploads
+  - name: copyparty.julianverse.net
+    type: webapp
+    machine: 192.168.0.13
+    port: 3923

--- a/playbooks/services/deploy_copyparty.yaml
+++ b/playbooks/services/deploy_copyparty.yaml
@@ -1,0 +1,16 @@
+- name: Deploy Copyparty
+  hosts: daphne
+  become: yes
+
+  roles:
+    - role: docker_service
+      vars:
+        service_name: copyparty
+        compose_template: copyparty-compose.yml.j2
+        config_files:
+          - src: copyparty.conf.j2
+            dest: copyparty.conf
+        service_directories:
+          - data
+          - hists
+        docker_compose_state: present

--- a/templates/copyparty-compose.yml.j2
+++ b/templates/copyparty-compose.yml.j2
@@ -1,0 +1,11 @@
+services:
+  copyparty:
+    image: copyparty/ac:latest
+    container_name: copyparty
+    restart: unless-stopped
+    ports:
+      - 3923:3923
+    volumes:
+      - ./copyparty.conf:/cfg/copyparty.conf
+      - ./data:/data
+      - ./hists:/cfg/hists

--- a/templates/copyparty.conf.j2
+++ b/templates/copyparty.conf.j2
@@ -1,0 +1,15 @@
+[global]
+# Store database and thumbnails in config directory
+hist: /cfg/hists/
+
+[accounts]
+# Define users here
+# admin: secretpassword
+
+[/]
+# Root volume - expose /data directory
+/data
+
+# Set permissions (r=read, w=write, d=delete, a=admin)
+# accs:
+#   rwda: admin


### PR DESCRIPTION
- Add docker-compose template for copyparty using copyparty/ac image
- Add copyparty.conf template with basic configuration
- Add deploy_copyparty.yaml playbook targeting daphne host
- Register copyparty.julianverse.net in services.yaml for reverse proxy