### PR TITLE
fix: add static DNS resolution for octoprint.local

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -48,3 +48,9 @@ otherhosts:
       ansible_host: 10.10.0.40
       exporter_port: 9182
       description: Windows desktop with WSL2, GPU-enabled for AI workloads
+other:
+  hosts:
+    octoprint:
+      ansible_host: 10.10.1.32
+      mdns_name: octoprint.local
+      description: OctoPrint 3D printer management server

--- a/templates/pihole-custom-dns.conf.j2
+++ b/templates/pihole-custom-dns.conf.j2
@@ -11,3 +11,8 @@ address=/{{ host }}.fg/{{ hostvars[host]['ansible_host'] }}
 {% for host in groups['otherhosts'] %}
 address=/{{ host }}.fg/{{ hostvars[host]['ansible_host'] }}
 {% endfor %}
+
+# mDNS / .local devices
+{% for host in groups['other'] %}
+address=/{{ hostvars[host]['mdns_name'] }}/{{ hostvars[host]['ansible_host'] }}
+{% endfor %}


### PR DESCRIPTION
Adds static dnsmasq entry for octoprint.local (10.10.1.32) in Pi-hole via new `other` inventory group.

Closes #8

Generated with [Claude Code](https://claude.ai/code)